### PR TITLE
feat: Event and EventParticipant REST API with access control

### DIFF
--- a/backend/app/Http/Controllers/EventController.php
+++ b/backend/app/Http/Controllers/EventController.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Event;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class EventController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        try {
+            $events = Event::with(['creator', 'location', 'category', 'participants'])->get(); // Trae los eventos con sus relaciones
+
+            return response()->json([
+                'message' => 'Events retrieved successfully',
+                'events' => $events,
+            ]);
+        } catch (\Exception $e) {
+            return response()->json([
+                'message' => 'Error fetching events',
+                'error' => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    public function myEvents()
+    {
+        try {
+            $events = Event::with(['location', 'category', 'participants'])
+                ->where('creator_id', Auth::id())
+                ->get();
+
+            return response()->json([
+                'message' => 'My events retrieved successfully',
+                'events' => $events,
+            ]);
+        } catch (\Exception $e) {
+            return response()->json([
+                'message' => 'Error fetching my events',
+                'error' => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        try {
+            $validated = $request->validate([
+                'location_id' => 'nullable|exists:locations,id',
+                'category_id' => 'nullable|exists:event_categories,id',
+                'title' => 'required|string|max:255',
+                'description' => 'nullable|string',
+                'participant_limit' => 'nullable|integer',
+                'start_date' => 'required|date',
+                'end_date' => 'required|date',
+                'start_time' => 'required|date_format:H:i',
+                'end_time' => 'required|date_format:H:i',
+            ]);
+
+            $user = Auth::user();
+
+            $event = Event::create([
+                'creator_id' => $user->id,
+                ...$validated,
+            ]);
+
+            // Agregamos al creador como participante
+            $event->participants()->attach($user->id);
+
+            return response()->json([
+                'message' => 'Event created successfully',
+                'event' => $event,
+            ], 201);
+        } catch (\Exception $e) {
+            return response()->json([
+                'message' => 'Error creating event',
+                'error' => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Event $event)
+    {
+        try {
+            if ($event->creator_id !== Auth::id()) {
+                return response()->json([
+                    'message' => 'Unauthorized to view this event',
+                ], 403);
+            }
+
+            $event->load(['creator', 'location', 'category', 'participants']);
+
+            return response()->json([
+                'message' => 'Event retrieved successfully',
+                'event' => $event,
+            ]);
+        } catch (\Exception $e) {
+            return response()->json([
+                'message' => 'Error fetching event',
+                'error' => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+
+    public function update(Request $request, Event $event)
+    {
+        try {
+            if ($event->creator_id !== Auth::id()) {
+                return response()->json([
+                    'message' => 'Unauthorized to update this event',
+                ], 403);
+            }
+
+            $validated = $request->validate([
+                'title' => 'required|string|max:255',
+                'description' => 'nullable|string',
+                'participant_limit' => 'nullable|integer',
+                'start_date' => 'required|date',
+                'end_date' => 'required|date',
+                'start_time' => 'required|date_format:H:i',
+                'end_time' => 'required|date_format:H:i',
+            ]);
+
+            $event->update($validated);
+
+            return response()->json([
+                'message' => 'Event updated successfully',
+                'event' => $event,
+            ]);
+        } catch (\Exception $e) {
+            return response()->json([
+                'message' => 'Error updating event',
+                'error' => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Event $event)
+    {
+        try {
+            if ($event->creator_id !== Auth::id()) {
+                return response()->json([
+                    'message' => 'Unauthorized to delete this event',
+                ], 403);
+            }
+
+            $event->delete();
+
+            return response()->json([
+                'message' => 'Event deleted successfully',
+            ]);
+        } catch (\Exception $e) {
+            return response()->json([
+                'message' => 'Error deleting event',
+                'error' => $e->getMessage(),
+            ], 500);
+        }
+    }
+}

--- a/backend/app/Http/Controllers/EventParticipantController.php
+++ b/backend/app/Http/Controllers/EventParticipantController.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Event;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class EventParticipantController extends Controller
+{
+    /**
+     * Listar eventos en los que está participando el usuario autenticado
+     */
+    public function participatingEvents()
+    {
+        $user = Auth::user();
+        $user = User::find($user->id);
+        $events = $user->joinedEvents()->with('location', 'category')->get();
+
+        return response()->json($events);
+    }
+
+    /**
+     * Listar los usuarios participantes de un evento (Solo lo puede ver el creador del evento)
+     */
+    public function showParticipants($event_id)
+    {
+        $event = Event::findOrFail($event_id);
+
+        // Validación: solo el creador puede ver los participantes
+        if ($event->creator_id !== Auth::id()) {
+            return response()->json(['message' => 'Unauthorized'], 403);
+        }
+
+        return response()->json($event->participants()->get());
+    }
+
+
+    /**
+     * Register the authenticated user as a participant in the given event.
+     */
+    public function store(Request $request)
+    {
+        try {
+            $validated = $request->validate([
+                'event_id' => 'required|exists:events,id',
+            ]);
+
+            $user = Auth::user(); // O puedes usar $request->user() si usas auth middleware
+            $event = Event::findOrFail($validated['event_id']);
+
+            // Evitar duplicados (aunque ya tienes unique en la migración)
+            if ($event->participants()->where('user_id', $user->id)->exists()) {
+                return response()->json([
+                    'message' => 'You are already registered in this event.',
+                ], 409);
+            }
+
+            // Asociar usuario al evento
+            $event->participants()->attach($user->id);
+
+            return response()->json([
+                'message' => 'Successfully registered for the event.',
+            ], 201);
+        } catch (\Exception $e) {
+            return response()->json([
+                'message' => 'Error registering for event.',
+                'error' => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+/**
+ * Remove the authenticated user from the event participants.
+ */
+public function destroy(Request $request, $event_id)
+{
+    try {
+        $user = Auth::user();
+        $event = Event::findOrFail($event_id);
+
+        // Verificar si el usuario es el creador del evento
+        if ($event->creator_id === $user->id) {
+            return response()->json([
+                'message' => 'You cannot unregister from your own event.',
+            ], 403);
+        }
+
+        // Eliminar la participación
+        $event->participants()->detach($user->id);
+
+        return response()->json([
+            'message' => 'Successfully unregistered from the event.',
+        ]);
+    } catch (\Exception $e) {
+        return response()->json([
+            'message' => 'Error unregistering from event.',
+            'error' => $e->getMessage(),
+        ], 500);
+    }
+}
+
+}

--- a/backend/app/Models/Event.php
+++ b/backend/app/Models/Event.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+class Event extends Model
+{
+    use HasFactory, HasUuids;
+
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'creator_id',
+        'location_id',
+        'category_id',
+        'title',
+        'description',
+        'participant_limit',
+        'start_date',
+        'end_date',
+        'start_time',
+        'end_time',
+    ];
+
+    protected $casts = [
+        'start_date' => 'date',
+        'end_date' => 'date',
+        'start_time' => 'datetime:H:i',
+        'end_time' => 'datetime:H:i',
+    ];
+
+    /*
+    |--------------------------------------------------------------------------
+    | Relaciones
+    |--------------------------------------------------------------------------
+    */
+
+    // Creador del evento (User)
+    public function creator()
+    {
+        return $this->belongsTo(User::class, 'creator_id');
+    }
+
+    // Ubicación del evento (Location)
+    public function location()
+    {
+        return $this->belongsTo(Location::class);
+    }
+
+    // Categoría del evento (EventCategory)
+    public function category()
+    {
+        return $this->belongsTo(EventCategory::class);
+    }
+
+    // Obtener cuantos Users apuntados hay en el Event
+    public function participants()
+    {
+        return $this->belongsToMany(User::class, 'event_participants')->withTimestamps();
+    }
+}

--- a/backend/app/Models/EventParticipant.php
+++ b/backend/app/Models/EventParticipant.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class EventParticipant extends Model
+{
+    protected $fillable = [
+        'event_id',
+        'user_id'
+    ];
+
+    public function event()
+    {
+        return $this->belongsTo(Event::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -12,8 +12,7 @@ class User extends Authenticatable implements JWTSubject
 {
     use HasFactory, Notifiable, HasUuids; // HasUuids generate auto id when we create a user
 
-    protected $primaryKey = 'id'; 
-    public $incrementing = false; 
+    public $incrementing = false;
     protected $keyType = 'string';
 
     /**
@@ -76,5 +75,24 @@ class User extends Authenticatable implements JWTSubject
             'user_type' => 'string',
             'role' => 'string',
         ];
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Relaciones
+    |--------------------------------------------------------------------------
+    */
+
+    // Obtener eventos creados por el User
+    public function createdEvents()
+    {
+        return $this->hasMany(Event::class, 'creator_id');
+    }
+
+    // Obtener en cuantos eventos participa el User
+    public function joinedEvents()
+    {
+        return $this->belongsToMany(Event::class, 'event_participants')
+            ->withTimestamps();
     }
 }

--- a/backend/database/migrations/2025_04_14_110639_create_events_table.php
+++ b/backend/database/migrations/2025_04_14_110639_create_events_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('events', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            
+            // Clave foránea UUID para 'users'
+            $table->uuid('creator_id');
+            $table->foreign('creator_id')->references('id')->on('users')->onDelete('cascade');        
+            
+            // Claves foráneas autoincrementales
+            $table->foreignId('location_id')->nullable()->constrained('locations')->onDelete('set null');
+            $table->foreignId('category_id')->nullable()->constrained('event_categories')->onDelete('set null');
+            
+            $table->string('title');
+            $table->text('description')->nullable();
+            $table->integer('participant_limit')->nullable();
+            $table->date('start_date');
+            $table->date('end_date');
+            $table->time('start_time');
+            $table->time('end_time');
+            $table->timestamps();
+        });
+        
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('events');
+    }
+};

--- a/backend/database/migrations/2025_04_14_114618_create_event_participants_table.php
+++ b/backend/database/migrations/2025_04_14_114618_create_event_participants_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('event_participants', function (Blueprint $table) {
+            $table->id();
+
+            // Clave foránea UUID para 'users'
+            $table->uuid('event_id');
+            $table->foreign('event_id')->references('id')->on('events')->onDelete('cascade');
+            $table->uuid('user_id');
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+
+            $table->timestamps();
+
+            $table->unique(['event_id', 'user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('event_participants');
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -5,6 +5,8 @@ use App\Http\Controllers\AuthController;
 use App\Http\Controllers\UserController;
 use App\Http\Controllers\AdminUserController;
 use App\Http\Controllers\EventCategoryController;
+use App\Http\Controllers\EventController;
+use App\Http\Controllers\EventParticipantController;
 use App\Http\Controllers\LocationController;
 use App\Http\Middleware\IsUserAuth;
 use App\Http\Middleware\IsAdmin;
@@ -27,6 +29,20 @@ Route::middleware([IsUserAuth::class])->group(function () {
     Route::get('/locations', [LocationController::class, 'index']);
     Route::get('/locations/{location}', [LocationController::class, 'show']);
 
+    // Events
+    Route::get('/my-events', [EventController::class, 'myEvents']);
+    Route::post('/events', [EventController::class, 'store']);
+    Route::get('/events/{event}', [EventController::class, 'show']);
+    Route::put('/events/{event}', [EventController::class, 'update']);
+    Route::delete('/events/{event}', [EventController::class, 'destroy']);
+
+    // Event participants
+    Route::get('/user/participating-events', [EventParticipantController::class, 'participatingEvents']);  // Listar eventos en los que el usuario está participando
+    Route::get('/events/{event_id}/participants', [EventParticipantController::class, 'showParticipants']);  // Mostrar participantes de un evento
+    Route::post('/event-participants', [EventParticipantController::class, 'store']);
+    Route::delete('/event-participants/{event_id}', [EventParticipantController::class, 'destroy']);
+
+
     // Rutas exclusivas para el administrador
     Route::middleware([IsAdmin::class])->group(function () {
 
@@ -44,10 +60,13 @@ Route::middleware([IsUserAuth::class])->group(function () {
         Route::post('/event-categories', [EventCategoryController::class, 'store']);
         Route::put('/event-categories/{eventCategory}', [EventCategoryController::class, 'update']);
         Route::delete('/event-categories/{eventCategory}', [EventCategoryController::class, 'destroy']);
-        
+
         // Locations
         Route::post('/locations', [LocationController::class, 'store']);
         Route::put('/locations/{location}', [LocationController::class, 'update']);
         Route::delete('/locations/{location}', [LocationController::class, 'destroy']);
+
+        // Events
+        Route::get('/events', [EventController::class, 'index']);
     });
 });


### PR DESCRIPTION
Add Event and EventParticipant models with full REST API and participation logic

- Created models and migrations for Event and EventParticipant
- Implemented full RESTful API for managing events (CRUD)
- Added endpoints to allow users to join or leave events
- Prevented event creators from leaving their own events
- Added ability to list user's joined events and event participants
- Applied necessary validation and authorization checksation and authorization checks