### PR TITLE
Fix event participant route

### DIFF
--- a/backend/app/Http/Controllers/EventParticipantController.php
+++ b/backend/app/Http/Controllers/EventParticipantController.php
@@ -38,11 +38,9 @@ class EventParticipantController extends Controller
      * List the users participating in an event.
      * Only the event creator can view this information.
      */
-    public function showParticipants($event_id)
+    public function showParticipants(Event $event)
     {
         try {
-            $event = Event::findOrFail($event_id);
-
             // Get the participants of the event
             $participants = $event->participants()->get();
 
@@ -111,11 +109,10 @@ class EventParticipantController extends Controller
     /**
      * Remove the authenticated user from the event participants.
      */
-    public function destroy($event_id)
+    public function destroy(Event $event)
     {
         try {
             $user = Auth::user();
-            $event = Event::findOrFail($event_id);
 
             // Check if the user is the creator of the event
             if ($event->creator_id === $user->id) {

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -46,9 +46,9 @@ Route::middleware([IsUserAuth::class])->group(function () {
 
     // Event participants
     Route::get('/user/participating-events', [EventParticipantController::class, 'participatingEvents']); // Listar eventos en los que el usuario está participando
-    Route::get('/events/{event_participant}/participants', [EventParticipantController::class, 'showParticipants']); // Mostrar participantes de un evento
+    Route::get('/events/{event}/participants', [EventParticipantController::class, 'showParticipants']); // Mostrar participantes de un evento
     Route::post('/event-participants', [EventParticipantController::class, 'store']);
-    Route::delete('/event-participants/{event_participant}', [EventParticipantController::class, 'destroy']);
+    Route::delete('/event-participants/{event}', [EventParticipantController::class, 'destroy']);
 
     // Rutas exclusivas para el administrador
     Route::middleware([IsAdmin::class])->group(function () {


### PR DESCRIPTION
Refactors the EventParticipantController to use Laravel's implicit Route Model Binding by replacing the $event_id parameter with a type-hinted Event $event. 