### PR TITLE
feat: make hidden user attributes visible in event relations (creator and participants)

### DIFF
--- a/backend/app/Http/Controllers/Admin/AdminEventController.php
+++ b/backend/app/Http/Controllers/Admin/AdminEventController.php
@@ -22,8 +22,16 @@ class AdminEventController extends Controller
                 $query->where('title', 'like', '%' . $request->title . '%');
             }
 
+            /** @var \App\Models\Event $events */
             // Execute query with pagination (10 per page)
             $events = $query->paginate(10);
+
+
+            // Make hidden fields of the creator and participants visible for each event
+            $events->getCollection()->each(function ($event) {
+                $event->creator->makeVisible(['profile_image', 'user_type', 'role']);
+                $event->participants->makeVisible(['profile_image', 'user_type', 'role']);
+            });
 
             return response()->json([
                 'message' => 'Events retrieved successfully.',

--- a/backend/app/Http/Controllers/EventController.php
+++ b/backend/app/Http/Controllers/EventController.php
@@ -19,6 +19,8 @@ class EventController extends Controller
                 ->where('creator_id', Auth::id())
                 ->get();
 
+            $events->makeVisible(['profile_image', 'user_type', 'role']);
+
             return response()->json([
                 'message' => 'Your events were retrieved successfully.',
                 'events' => $events,
@@ -89,6 +91,10 @@ class EventController extends Controller
     {
         try {
             $event->load(['creator', 'location', 'category', 'participants']);
+
+            // Make hidden fields of the creator and participants visible
+            $event->creator->makeVisible(['profile_image', 'user_type', 'role']);
+            $event->participants->makeVisible(['profile_image', 'user_type', 'role']);
 
             return response()->json([
                 'message' => 'Event retrieved successfully.',

--- a/backend/app/Http/Controllers/EventParticipantController.php
+++ b/backend/app/Http/Controllers/EventParticipantController.php
@@ -41,8 +41,8 @@ class EventParticipantController extends Controller
     public function showParticipants(Event $event)
     {
         try {
-            // Get the participants of the event
-            $participants = $event->participants()->get();
+            // Retrieve the participants of the event and make their hidden fields visible
+            $participants = $event->participants->makeVisible(['profile_image', 'user_type', 'role']);
 
             return response()->json([
                 'message' => 'Event participants retrieved successfully.',


### PR DESCRIPTION
- Applied `makeVisible` to expose 'profile_image', 'user_type', and 'role' fields
  in the `creator` and `participants` relationships of Event.
- Updated EventController AdminEventController EventParticipantController.