### PR TITLE
Refactor EventParticipant deletion logic and models for improved clarity and performance

### DIFF
--- a/backend/app/Http/Middleware/EnsureUserOwnsEvent.php
+++ b/backend/app/Http/Middleware/EnsureUserOwnsEvent.php
@@ -8,21 +8,32 @@ use Illuminate\Support\Facades\Auth;
 class EnsureUserOwnsEvent
 {
     /**
-     * Handle an incoming request.
+     * Handle an incoming request to ensure the user owns the event or is an admin.
      *
+     * @param  \Illuminate\Http\Request  $request
      * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     public function handle($request, Closure $next)
     {
-        // Obtenemos parametro de la ruta
+        // Retrieve the 'event' parameter from the route
         $event = $request->route('event');
 
         if (!$event) {
             return response()->json(['message' => 'Event not found'], 404);
         }
 
-        if ($event->creator_id !== Auth::id() && Auth::user()->role !== 'admin') {
-            return response()->json(['message' => 'Unauthorized'], 403);
+        // Check if the authenticated user is the creator of the event
+        $isCreator = $event->creator_id === Auth::id();
+
+        // Check if the authenticated user is an admin
+        $isAdmin = Auth::user()->role === 'admin';
+
+        // If neither condition is true, return a forbidden response
+        if (!$isCreator && !$isAdmin) {
+            return response()->json([
+                'message' => 'You do not have permission to access this event. Only the event creator or an admin can access it.'
+            ], 403);
         }
 
         return $next($request);

--- a/backend/app/Http/Middleware/IsAdmin.php
+++ b/backend/app/Http/Middleware/IsAdmin.php
@@ -9,17 +9,23 @@ use Symfony\Component\HttpFoundation\Response;
 class IsAdmin
 {
     /**
-     * Handle an incoming request.
+     * Handle an incoming request and check if the user has 'admin' role.
      *
+     * @param  \Illuminate\Http\Request  $request
      * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     public function handle(Request $request, Closure $next): Response
     {
+        // Retrieve the authenticated user from the API guard
         $user = auth('api')->user();
+
         if ($user && $user->role === 'admin') {
             return $next($request);
-        } else {
-            return response()->json(['message' => 'You are not an ADMIN'], 403);
         }
+
+        return response()->json([
+            'message' => 'You are not authorized to access this resource. Admin privileges are required.'
+        ], 403);
     }
 }

--- a/backend/app/Http/Middleware/IsUserAuth.php
+++ b/backend/app/Http/Middleware/IsUserAuth.php
@@ -9,16 +9,23 @@ use Symfony\Component\HttpFoundation\Response;
 class IsUserAuth
 {
     /**
-     * Handle an incoming request.
+     * Handle an incoming request and check if the user is authenticated.
      *
+     * @param  \Illuminate\Http\Request  $request
      * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     public function handle(Request $request, Closure $next): Response
     {
-        if(auth('api')->user()){
+        // Check if the user is authenticated using the 'api' guard
+        $user = auth('api')->user();
+
+        if ($user) {
             return $next($request);
-        }else{
-            return response()->json(['message' => 'Unauthorized'], 401);
         }
+
+        return response()->json([
+            'message' => 'You must be authenticated to access this resource.'
+        ], 401);
     }
 }

--- a/backend/app/Models/Event.php
+++ b/backend/app/Models/Event.php
@@ -2,8 +2,8 @@
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 
 class Event extends Model
@@ -31,35 +31,37 @@ class Event extends Model
         'end_date' => 'date',
         'start_time' => 'datetime:H:i',
         'end_time' => 'datetime:H:i',
+        'participant_limit' => 'integer',
     ];
 
     /*
     |--------------------------------------------------------------------------
-    | Relations
+    | Relationships
     |--------------------------------------------------------------------------
     */
 
-    // Creador del evento (User)
+    // Creator of the event
     public function creator()
     {
         return $this->belongsTo(User::class, 'creator_id');
     }
 
-    // Ubicación del evento (Location)
+    // Event location
     public function location()
     {
         return $this->belongsTo(Location::class);
     }
 
-    // Categoría del evento (EventCategory)
+    // Event category
     public function category()
     {
         return $this->belongsTo(EventCategory::class);
     }
 
-    // Obtener cuantos Users apuntados hay en el Event
+    // Users participating in the event
     public function participants()
     {
-        return $this->belongsToMany(User::class, 'event_participants')->withTimestamps();
+        return $this->belongsToMany(User::class, 'event_participants')
+            ->withTimestamps();
     }
 }

--- a/backend/app/Models/EventCategory.php
+++ b/backend/app/Models/EventCategory.php
@@ -7,8 +7,29 @@ use Illuminate\Database\Eloquent\Model;
 
 class EventCategory extends Model
 {
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
     protected $fillable = [
         'name',
         'description',
     ];
+
+    /*
+    |--------------------------------------------------------------------------
+    | Relationships
+    |--------------------------------------------------------------------------
+    */
+
+    /**
+     * Get all events that belong to this category.
+     */
+    public function events()
+    {
+        return $this->hasMany(Event::class, 'category_id');
+    }
 }

--- a/backend/app/Models/EventParticipant.php
+++ b/backend/app/Models/EventParticipant.php
@@ -7,16 +7,35 @@ use Illuminate\Database\Eloquent\Model;
 
 class EventParticipant extends Model
 {
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
     protected $fillable = [
         'event_id',
-        'user_id'
+        'user_id',
     ];
 
+    /*
+    |--------------------------------------------------------------------------
+    | Relationships
+    |--------------------------------------------------------------------------
+    */
+
+    /**
+     * Get the event associated with this participation.
+     */
     public function event()
     {
         return $this->belongsTo(Event::class);
     }
 
+    /**
+     * Get the user who is participating in the event.
+     */
     public function user()
     {
         return $this->belongsTo(User::class);

--- a/backend/app/Models/Location.php
+++ b/backend/app/Models/Location.php
@@ -2,22 +2,34 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Location extends Model
 {
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
     protected $fillable = [
         'name',
         'address',
         'latitude',
-        'longitude'
+        'longitude',
     ];
 
     /*
     |--------------------------------------------------------------------------
-    | Relations
+    | Relationships
     |--------------------------------------------------------------------------
     */
+
+    /**
+     * Get the event that takes place at this location.
+     */
     public function event()
     {
         return $this->hasOne(Event::class, 'location_id');

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -10,7 +10,7 @@ use Tymon\JWTAuth\Contracts\JWTSubject;
 
 class User extends Authenticatable implements JWTSubject
 {
-    use HasFactory, Notifiable, HasUuids; // HasUuids generate auto id when we create a user
+    use HasFactory, Notifiable, HasUuids;
 
     public $incrementing = false;
     protected $keyType = 'string';
@@ -30,7 +30,7 @@ class User extends Authenticatable implements JWTSubject
     ];
 
     /**
-     * The attributes that should be hidden for serialization.
+     * The attributes that should be hidden for arrays and JSON.
      *
      * @var list<string>
      */
@@ -42,28 +42,8 @@ class User extends Authenticatable implements JWTSubject
         'role',
     ];
 
-    /** 
-     * Devuelve el identificador que será almacenado en el token JWT. 
-     * 
-     * @return mixed 
-     */
-    public function getJWTIdentifier()
-    {
-        return $this->getKey();
-    }
-
-    /** 
-     * Devuelve un arreglo de claims personalizados para el token JWT. 
-     * 
-     * @return array<string, mixed> 
-     */
-    public function getJWTCustomClaims()
-    {
-        return [];
-    }
-
     /**
-     * Get the attributes that should be cast.
+     * The attributes that should be cast to native types.
      *
      * @return array<string, string>
      */
@@ -79,20 +59,49 @@ class User extends Authenticatable implements JWTSubject
 
     /*
     |--------------------------------------------------------------------------
-    | Relations
+    | JWT Methods
     |--------------------------------------------------------------------------
     */
 
-    // Obtener eventos creados por el User
+    /**
+     * Get the identifier that will be stored in the JWT subject claim.
+     *
+     * @return mixed
+     */
+    public function getJWTIdentifier(): mixed
+    {
+        return $this->getKey();
+    }
+
+    /**
+     * Return a key-value array of custom claims to be added to the JWT.
+     *
+     * @return array<string, mixed>
+     */
+    public function getJWTCustomClaims(): array
+    {
+        return [];
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Relationships
+    |--------------------------------------------------------------------------
+    */
+
+    /**
+     * Get all events created by the user.
+     */
     public function createdEvents()
     {
         return $this->hasMany(Event::class, 'creator_id');
     }
 
-    // Obtener en cuantos eventos participa el User
+    /**
+     * Get all events the user has joined.
+     */
     public function joinedEvents()
     {
-        return $this->belongsToMany(Event::class, 'event_participants')
-            ->withTimestamps();
+        return $this->belongsToMany(Event::class, 'event_participants')->withTimestamps();
     }
 }

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\EventCategoryController;
 use App\Http\Controllers\EventController;
 use App\Http\Controllers\EventParticipantController;
 use App\Http\Controllers\LocationController;
+use App\Http\Middleware\EnsureUserOwnsEventParticipant;
 use App\Http\Middleware\IsUserAuth;
 use App\Http\Middleware\IsAdmin;
 
@@ -48,7 +49,8 @@ Route::middleware([IsUserAuth::class])->group(function () {
     Route::get('/user/participating-events', [EventParticipantController::class, 'participatingEvents']); // Listar eventos en los que el usuario está participando
     Route::get('/events/{event}/participants', [EventParticipantController::class, 'showParticipants']); // Mostrar participantes de un evento
     Route::post('/event-participants', [EventParticipantController::class, 'store']);
-    Route::delete('/event-participants/{event}', [EventParticipantController::class, 'destroy']);
+    Route::delete('/events/{event}/participants/{user}', [EventParticipantController::class, 'destroy'])->middleware([EnsureUserOwnsEventParticipant::class]);
+
 
     // Rutas exclusivas para el administrador
     Route::middleware([IsAdmin::class])->group(function () {


### PR DESCRIPTION
- Refactor the `destroy` method for removing event participation:
  - Removed redundant checks for user registration within the event, as the middleware already ensures the user's eligibility.
  - Simplified the logic by handling permissions directly in the middleware, ensuring only participants, event creators, or admins can remove participants.
  - Prevent event creators from being removed from the event.
  
- Refactor all models for better clarity:
  - Improved method naming and code structure for easier maintenance.
  - Optimized relationships and streamlined queries.