### PR TITLE
feat: resolved location handling in the frontend

### DIFF
--- a/backend/app/Http/Controllers/EventController.php
+++ b/backend/app/Http/Controllers/EventController.php
@@ -108,7 +108,6 @@ class EventController extends Controller
         }
     }
 
-
     /**
      * Update the specified event.
      */
@@ -119,6 +118,8 @@ class EventController extends Controller
             'title' => 'required|string|max:255',
             'description' => 'nullable|string',
             'participant_limit' => 'nullable|integer|max:100',
+            'location_id' => 'nullable|exists:locations,id',
+            'category_id' => 'nullable|exists:categories,id',
             'start_date' => 'required|date',
             'end_date' => 'required|date|after_or_equal:start_date',
             'start_time' => 'required|date_format:H:i',
@@ -134,16 +135,19 @@ class EventController extends Controller
         }
 
         try {
-            // Update the event with the validated data
-            $event->update($validator->validated());
+            $data = $validator->validated();
 
-            // Return success response
+            // Update the event with the validated data
+            $event->update($data);
+
+            // Load the location relation if you want to return it as well
+            $event->load('location', 'category');
+
             return response()->json([
                 'message' => 'Event updated successfully.',
                 'event' => $event,
             ], 200);
         } catch (\Exception $e) {
-            // Return error response if an exception occurs
             return response()->json([
                 'message' => 'Error updating the event.',
                 'error' => $e->getMessage(),

--- a/backend/app/Http/Controllers/LocationController.php
+++ b/backend/app/Http/Controllers/LocationController.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Location;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
+use App\Models\Location;
 
 class LocationController extends Controller
 {

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -29,10 +29,10 @@ Route::middleware([IsUserAuth::class])->group(function () {
 
     // Locations
     Route::get('/locations/{location}', [LocationController::class, 'show']);
+    Route::delete('/locations/{location}', [LocationController::class, 'destroy']);
     Route::post('/locations', [LocationController::class, 'store']);
     Route::middleware('location.owner_or_admin')->group(function () {
         Route::put('/locations/{location}', [LocationController::class, 'update']);
-        Route::delete('/locations/{location}', [LocationController::class, 'destroy']);
     });
 
     // Events

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,13 +10,16 @@
       "dependencies": {
         "@tailwindcss/vite": "^4.0.6",
         "axios": "^1.8.1",
+        "leaflet": "^1.9.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-leaflet": "^5.0.0",
         "react-router-dom": "^7.2.0",
         "tailwindcss": "^4.0.6"
       },
       "devDependencies": {
         "@eslint/js": "^9.19.0",
+        "@types/leaflet": "^1.9.17",
         "@types/react": "^19.0.8",
         "@types/react-dom": "^19.0.3",
         "@vitejs/plugin-react-swc": "^3.5.0",
@@ -685,6 +688,17 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@react-leaflet/core": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0.tgz",
+      "integrity": "sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ==",
+      "license": "Hippocratic-2.1",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1396,12 +1410,29 @@
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
       "license": "MIT"
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.17",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.17.tgz",
+      "integrity": "sha512-IJ4K6t7I3Fh5qXbQ1uwL3CFVbCi6haW9+53oLWgdKlLP7EaS21byWFJxxqOx9y8I0AP0actXSJLVMbyvxhkUTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.0.10",
@@ -2661,6 +2692,12 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -3221,6 +3258,20 @@
       },
       "peerDependencies": {
         "react": "^19.0.0"
+      }
+    },
+    "node_modules/react-leaflet": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0.tgz",
+      "integrity": "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==",
+      "license": "Hippocratic-2.1",
+      "dependencies": {
+        "@react-leaflet/core": "^3.0.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
       }
     },
     "node_modules/react-router": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,13 +12,16 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.0.6",
     "axios": "^1.8.1",
+    "leaflet": "^1.9.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-leaflet": "^5.0.0",
     "react-router-dom": "^7.2.0",
     "tailwindcss": "^4.0.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.19.0",
+    "@types/leaflet": "^1.9.17",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",
     "@vitejs/plugin-react-swc": "^3.5.0",

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
+import "leaflet/dist/leaflet.css";
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(

--- a/frontend/src/pages/admin/events/EventPage.tsx
+++ b/frontend/src/pages/admin/events/EventPage.tsx
@@ -46,6 +46,7 @@ export const EventPage: React.FC = () => {
         events={events}
         onEdit={handleEdit}
         onDelete={handleDelete}
+        refreshEvents={fetchEventsByUrl}
       />
 
       {(loading || updating) && <p>Cargando eventos...</p>}

--- a/frontend/src/pages/admin/events/components/EventTable.tsx
+++ b/frontend/src/pages/admin/events/components/EventTable.tsx
@@ -1,7 +1,15 @@
 import React from "react";
 import { EventTableProps } from "../../../../types/event";
+import { LocationModal } from "../../location/LocationModal";
+import { UpdateLoction } from "../../../../types/location";
 
-export const EventTable: React.FC<EventTableProps> = ({ events, onEdit, onDelete }) => {
+export const EventTable: React.FC<EventTableProps> = ({ events, onEdit, onDelete, refreshEvents }) => {
+  const [selectedLocation, setSelectedLocation] = React.useState<UpdateLoction | null>(null);
+
+  const handleLocationClick = (location: UpdateLoction) => {
+    setSelectedLocation(location); // Establece la ubicación seleccionada
+  };
+
   return (
     <div className="overflow-x-auto">
       <table className="min-w-full bg-white shadow rounded-lg overflow-hidden table-fixed">
@@ -28,7 +36,10 @@ export const EventTable: React.FC<EventTableProps> = ({ events, onEdit, onDelete
                 })}{" "}
                 - {event.start_time}
               </td>
-              <td className="px-4 py-2 max-w-[150px] overflow-hidden text-ellipsis whitespace-nowrap">
+              <td
+                className="px-4 py-2 max-w-[150px] overflow-hidden text-ellipsis whitespace-nowrap cursor-pointer text-blue-500"
+                onClick={() => event.location && handleLocationClick({ id: event.location_id, name: event.location.name, latitude: event.location.latitude, longitude: event.location.longitude })}
+              >
                 {event.location ? event.location.name : "null"}
               </td>
               <td className="px-4 py-2 max-w-[150px] overflow-hidden text-ellipsis whitespace-nowrap">
@@ -53,6 +64,16 @@ export const EventTable: React.FC<EventTableProps> = ({ events, onEdit, onDelete
           ))}
         </tbody>
       </table>
+
+      {/* Modal: Pasa la ubicación seleccionada */}
+      {selectedLocation && (
+        <LocationModal
+          isOpen={Boolean(selectedLocation)}
+          onClose={() => setSelectedLocation(null)}
+          location={selectedLocation}
+          refreshEvents={refreshEvents}
+        />
+      )}
     </div>
   );
 };

--- a/frontend/src/pages/admin/events/components/PaginationButtons.tsx
+++ b/frontend/src/pages/admin/events/components/PaginationButtons.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { PaginationButtonsProps } from "../../../../types/admin";
+import { PaginationButtonsProps } from "../../../../types/user";
 
 export const PaginationButtons: React.FC<PaginationButtonsProps> = ({
     nextPageUrl,

--- a/frontend/src/pages/admin/location/LocationModal.tsx
+++ b/frontend/src/pages/admin/location/LocationModal.tsx
@@ -1,0 +1,102 @@
+import React, { useState } from "react";
+import { MapContainer, TileLayer, Marker, Popup, useMapEvent } from "react-leaflet";
+import { LocationModalProps } from "../../../types/location";
+import { updateLocation } from "../../../services/locationService"; // Importar el servicio
+
+export const LocationModal: React.FC<LocationModalProps> = ({ isOpen, onClose, location, refreshEvents }) => {
+    const [editedLocation, setEditedLocation] = useState(location);
+
+    // Usar useMapEvent para manejar el evento de clic en el mapa
+    const MapClickHandler = () => {
+        useMapEvent("click", (e) => {
+            const { lat, lng } = e.latlng;
+            setEditedLocation((prevState) => ({
+                ...prevState,
+                latitude: lat,
+                longitude: lng,
+            }));
+        });
+        return null;
+    };
+
+    const handleSaveLocation = async () => {
+        // Llamamos a la función de servicio para actualizar la ubicación
+        const updatedLocation = {
+            id: editedLocation.id,
+            name: editedLocation.name,
+            latitude: editedLocation.latitude,
+            longitude: editedLocation.longitude,
+        };
+
+        const result = await updateLocation(editedLocation.id, updatedLocation);
+
+        if (result) {
+            alert("Ubicación actualizada con éxito");
+            refreshEvents()
+            onClose(); // Cerrar el modal después de guardar
+        } else {
+            alert("Error al actualizar la ubicación");
+        }
+    };
+
+    return (
+        <div
+            className={`fixed inset-0 bg-gray-900 bg-opacity-50 z-50 transition-opacity ${isOpen ? "opacity-100" : "opacity-0 pointer-events-none"}`}
+            style={{ transition: "opacity 0.3s ease" }}
+        >
+            <div className="flex items-center justify-center min-h-screen">
+                <div className="bg-white rounded-lg p-6 w-11/12 sm:w-3/4 md:w-1/2">
+                    <div className="flex justify-between items-center mb-4">
+                        <h2 className="text-2xl font-semibold">Location Details</h2>
+                        <button onClick={onClose} className="text-gray-500 hover:text-gray-700">
+                            <span className="text-xl">X</span>
+                        </button>
+                    </div>
+                    <div className="mb-4">
+                        <label htmlFor="locationName" className="block text-sm font-medium text-gray-700">
+                            Location Name
+                        </label>
+                        <input
+                            id="locationName"
+                            type="text"
+                            value={editedLocation.name} // Cambiar a value para controlado
+                            onChange={(e) => setEditedLocation({ ...editedLocation, name: e.target.value })}
+                            className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                        />
+                    </div>
+                    <div className="relative h-80 mb-4">
+                        <MapContainer
+                            center={[editedLocation.latitude, editedLocation.longitude]}
+                            zoom={15}
+                            style={{ height: "100%", width: "100%" }}
+                        >
+                            <MapClickHandler /> {/* Llamamos al manejador de clics */}
+                            <TileLayer
+                                attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+                                url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                            />
+                            <Marker position={[editedLocation.latitude, editedLocation.longitude]}>
+                                <Popup>{editedLocation.name}</Popup>
+                            </Marker>
+                        </MapContainer>
+                    </div>
+                    <p>
+                        {editedLocation && `Lat: ${editedLocation.latitude}, Lng: ${editedLocation.longitude}`}
+                    </p>
+                    <button
+                        onClick={handleSaveLocation} // Guardar ubicación editada
+                        className="mt-4 w-full bg-blue-500 text-white py-2 rounded hover:bg-blue-600"
+                    >
+                        Save Location
+                    </button>
+                    <button
+                        onClick={onClose}
+                        className="mt-2 w-full bg-gray-500 text-white py-2 rounded hover:bg-gray-600"
+                    >
+                        Close
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/frontend/src/services/locationService.ts
+++ b/frontend/src/services/locationService.ts
@@ -1,0 +1,38 @@
+import { UpdateLoction } from "../types/location";
+import api from "./api";
+
+// Update location
+export const updateLocation = async (
+    id: number,
+    updatedLocation: {
+        name: string;
+        latitude: number;
+        longitude: number;
+    }
+): Promise<UpdateLoction | null> => {
+    try {
+        // Enviamos los datos al backend
+        const response = await api.put<UpdateLoction>(`/locations/${id}`, updatedLocation);
+
+        // Si no se recibe una respuesta adecuada
+        if (!response.data) {
+            console.warn("⚠️ No se pudo actualizar la ubicación.");
+            return null;
+        }
+
+        return response.data;
+    } catch (error: any) {
+        // Manejo de errores
+        if (error.response && error.response.data.errors) {
+            const errorMessages = Object.entries(error.response.data.errors)
+                .map(([, messages]) => `${(messages)}`)
+
+            alert(`❌ Error al actualizar la ubicación:\n\n${errorMessages}`);
+        } else {
+            // Si ocurre un error general
+            alert("❌ Error al actualizar la ubicación. Intenta nuevamente.");
+        }
+
+        return null;
+    }
+};

--- a/frontend/src/types/event.ts
+++ b/frontend/src/types/event.ts
@@ -49,6 +49,7 @@ export interface EventTableProps {
     events: Event[];
     onEdit: (id: string) => void;
     onDelete: (id: string) => void;
+    refreshEvents: () => void;
 }
 
 export interface EventFilterProps {

--- a/frontend/src/types/location.ts
+++ b/frontend/src/types/location.ts
@@ -1,9 +1,23 @@
 export interface Location {
-    id: number;
-    name: string;
-    address: string;
-    latitude: string;
-    longitude: string;
-    created_at: string;
-    updated_at: string;
-  }
+  id: number;
+  name: string;
+  address: string;
+  latitude: number;
+  longitude: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface LocationModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  location: UpdateLoction;
+  refreshEvents: () => void;
+}
+
+export interface UpdateLoction {
+  id: number;
+  name: string;
+  latitude: number;
+  longitude: number;
+}


### PR DESCRIPTION
- Fixed the issue with creating, deleting, and updating locations.
- Now it's possible to update the location of an event from the frontend using `react-leaflet` for map visualization.
- Added a modal to display and select the location for an event.
- Implemented functionality to delete and edit locations associated with events.

To-do:
- Implement the ability to create new locations for events.
- Add an input field to search for existing locations when updating a location.
