### PR TITLE
feat: add client-side image compression before uploading profile image

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@reduxjs/toolkit": "^2.8.1",
         "@tailwindcss/vite": "^4.0.6",
         "axios": "^1.8.1",
+        "browser-image-compression": "^2.0.2",
         "chart.js": "^4.4.9",
         "i18next": "^25.1.3",
         "i18next-browser-languagedetector": "^8.1.0",
@@ -2043,6 +2044,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/browser-image-compression": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
+      "license": "MIT",
+      "dependencies": {
+        "uzip": "0.20201231.0"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -4206,6 +4216,12 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "6.3.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "@reduxjs/toolkit": "^2.8.1",
     "@tailwindcss/vite": "^4.0.6",
     "axios": "^1.8.1",
+    "browser-image-compression": "^2.0.2",
     "chart.js": "^4.4.9",
     "i18next": "^25.1.3",
     "i18next-browser-languagedetector": "^8.1.0",

--- a/frontend/public/locales/en/profile.json
+++ b/frontend/public/locales/en/profile.json
@@ -26,5 +26,6 @@
                 "button": "Go admin panel"
             }
         }
-    }
+    },
+    "image_optimization_error": "There was a problem compressing the image. Please try a different one."
 }

--- a/frontend/public/locales/es/profile.json
+++ b/frontend/public/locales/es/profile.json
@@ -26,5 +26,6 @@
                 "button": "Cerrar sesión"
             }
         }
-    }
+    },
+    "image_optimization_error": "There was a problem compressing the image. Please try a different one."
 }

--- a/frontend/src/pages/user/profile/Profile.tsx
+++ b/frontend/src/pages/user/profile/Profile.tsx
@@ -8,6 +8,8 @@ import { ProfileActions } from "./component/ProfileActions";
 import { Loader } from "../../../shared/loader/Loader";
 import { ProfileSettingsPanel } from "./component/ProfileSettingsPanel";
 import { useTranslation } from "react-i18next";
+import toast from 'react-hot-toast';
+import imageCompression from 'browser-image-compression';
 
 export const Profile = () => {
   const { user } = useAuth();
@@ -32,9 +34,21 @@ export const Profile = () => {
   const handleImageChange = async (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
-      const formData = new FormData();
-      formData.append("profile_image", file);
-      await handleUpdateProfileImage(formData);
+      try {
+        const options = {
+          maxSizeMB: 1,
+          useWebWorker: true
+        };
+
+        const compressedFile = await imageCompression(file, options);
+
+        const formData = new FormData();
+        formData.append("profile_image", compressedFile);
+
+        await handleUpdateProfileImage(formData);
+      } catch (err) {
+        toast.error(t('image_optimization_error'));
+      }
     }
   };
 


### PR DESCRIPTION
Added compression using browser-image-compression to reduce image size and avoid 413 errors on upload. Also implemented error handling with toast notification for compression failures.